### PR TITLE
Adição do tb_config_countdown e do config_countdown

### DIFF
--- a/src/components/config_countdown.vhd
+++ b/src/components/config_countdown.vhd
@@ -1,0 +1,71 @@
+-- config_countdown
+--
+-- Contador regressivo configurável.
+--
+-- Funcionamento:
+--  - rst = '1': zera o contador e o valor de recarga (reset síncrono)
+--  - set = '1': salva N como o novo valor de recarga
+--  - Quando o contador chega a zero, ele recarrega com "proximo_valor"
+--
+-- Entradas:
+--   clk : clock
+--   rst : reset síncrono
+--   set : quando '1', grava N como o valor de recarga
+--   N   : valor que será carregado quando set='1'
+--
+-- Saída:
+--   X   : valor atual do contador
+--
+
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all; 
+
+entity config_countdown is
+	generic (
+    	WIDTH : integer := 16 --16 nesse caso é a largura de N (entrada)
+    );
+    port (
+    	clk : in std_logic;
+        rst : in std_logic;
+        set : in std_logic;
+        N : in  unsigned(WIDTH-1 downto 0);
+        X : out  unsigned(WIDTH-1 downto 0) --saida
+    );
+end entity;
+
+architecture rtl of config_countdown is 
+	signal valor_atual : unsigned(WIDTH-1 downto 0) := (others => '0');
+   	signal proximo_valor : unsigned(WIDTH-1 downto 0) := (others => '0');
+begin 
+	
+    process(clk) 
+    begin
+    	if rising_edge(clk) then 
+        	-- O RST sincronizado: limpa tudo:
+            if rst = '1' then
+            	valor_atual <= (others => '0');
+                proximo_valor <= (others => '0');
+          	else
+            
+                -- SET sincronizado: atualiza próximo valor
+                if set = '1' then 
+                    proximo_valor <= N;
+                    valor_atual   <= N;
+                end if;
+
+                -- comportamento do contador regressivo
+                if valor_atual = to_unsigned(0, width) then
+                    valor_atual <= proximo_valor; --reinicia o ciclo com o valor armazenado em proximo_valor
+                else
+                    valor_atual <= valor_atual - 1; --decrementa
+                end if;
+                
+            end if;
+            
+        end if;
+	end process;
+    
+X <= valor_atual;     
+
+end architecture;    

--- a/tests/tb_config_countdown.vhd
+++ b/tests/tb_config_countdown.vhd
@@ -1,0 +1,95 @@
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all;
+
+entity tb_config_countdown is
+end entity;
+
+architecture tb of tb_config_countdown is
+
+    constant width : integer := 8;
+    constant CLK_PERIOD : time := 10 ns;
+
+    -- UUT signals
+    signal clk_tb  : std_logic := '0';
+    signal rst_tb  : std_logic := '0';
+    signal set_tb  : std_logic := '0';
+    signal N_tb    : unsigned(width-1 downto 0) := (others => '0');
+    signal X_tb    : unsigned(width-1 downto 0);
+	signal clk_enable : boolean := true;
+
+
+begin
+
+    -- Instancia do DUT
+
+	UUT : entity work.config_countdown
+        generic map (width => width)
+        port map (
+            clk => clk_tb,
+            rst => rst_tb,
+            set => set_tb,
+            N   => N_tb,
+            X   => X_tb
+        );
+
+    -- Clock
+    
+    clk_process : process
+    begin
+        while clk_enable loop
+            clk_tb <= '0';
+            wait for CLK_PERIOD/2;
+            clk_tb <= '1';
+            wait for CLK_PERIOD/2;
+        end loop;
+
+        wait;  
+    end process;
+    
+    -- Estímulos
+    
+    stim : process
+    begin
+        report "===== INICIO DO TESTE =====";
+
+        -- RESET
+        rst_tb <= '1';
+        wait for CLK_PERIOD;
+        rst_tb <= '0';
+        wait for CLK_PERIOD;
+
+        -- 1) Carregar N = 10
+        N_tb   <= to_unsigned(10, width);
+        set_tb <= '1';
+        wait for CLK_PERIOD;
+        set_tb <= '0';
+
+        wait for 20*CLK_PERIOD;
+
+        -- 2) Mudar valor para N = 4
+        N_tb   <= to_unsigned(4, width);
+        set_tb <= '1';
+        wait for CLK_PERIOD;
+        set_tb <= '0';
+
+        wait for 15*CLK_PERIOD;
+
+        -- 3) Outro teste
+        N_tb   <= to_unsigned(15, width);
+        set_tb <= '1';
+        wait for CLK_PERIOD;
+        set_tb <= '0';
+
+        wait for 30*CLK_PERIOD;
+
+        report "===== FIM DA SIMULACAO =====" severity note;
+
+        clk_enable <= false;  -- ENCERRA O CLOCK
+        wait for CLK_PERIOD;  -- dá tempo do clock parar
+
+        wait;  
+
+    end process;
+
+end architecture;


### PR DESCRIPTION
config_countdown.vhd
//////////////////////////
config_countdown é um contador regressivo configurável.
Ele opera de forma totalmente síncrona e permite carregar dinamicamente um valor inicial para o contador.
Resumo 
rst = '1' → zera o contador e o valor de recarga.
set = '1' → grava o valor de entrada N em proximo_valor (armazenamento para recarga futura).
O contador decrementa a cada pulso de clock.
Quando chega a zero, recarrega automaticamente o valor salvo em proximo_valor.
A saída X sempre reflete o valor atual do contador.


tb_config_countdown.vhd
/////////////////////////////
O testbench verifica o comportamento do componente config_countdown, exercitando reset, carregamento de valores e operação normal do contador.
Resumo dos testes

Reset síncrono
Verifica se o contador e o valor de recarga são zerados corretamente.

Carregamento de novo valor (set=1)
Testa se o valor N é armazenado e usado no próximo ciclo de recarga.

Contagem regressiva normal
Observa a saída X decrementando até zero.

Recarregamento automático
Confirma que, ao atingir zero, o contador volta para proximo_valor.

Mudança dinâmica do valor N
Verifica se novos valores podem ser carregados enquanto o contador está em operação.