### PR TITLE
Feature/dataflow Pedro Armando

### DIFF
--- a/src/components/car_detector.vhd
+++ b/src/components/car_detector.vhd
@@ -1,61 +1,40 @@
 -- Detector de transição 0/1
 --
--- input:
---  In_Car: 1 bit - Entrada da fms
---   clk: 1 bit - Entrada do clock
--- output:
---   Out_Car: 1 bit - Saida 
---   ss: 1 bit - Saida do estado interno
---
 -- Integrantes:
 -- * Guilherme Augusto
 -- * Pedro Armando
 -- * Pedro Pessoa
+--
+-- input:
+--   CLK: 	1 bit - Entrada do clock
+--   SET: 	1 bit - Entrada do sensor
+-- output:
+--    Q: 	1 bit - Saida 
+--
 
 library IEEE;
 use IEEE.std_logic_1164.all;
 
-
 entity car_detector is port (
-    In_Car, CLK, RST : in std_logic; 
-    Out_Car : out std_logic;
-    SS : out std_logic
-); end entity;
+        SET	: in  std_logic;
+        CLK : in  std_logic;
+        Q 	: out std_logic
+        ); 
+end entity;
 
 
-architecture car_detector of car_detector is
-    signal PS, NS : std_logic;
+architecture Behavioral of car_detector is
+    
 begin
-    -- Processo sequencial
-    sync_proc: process(CLK, RST)
-begin
-    if RST = '1' then
-        PS <= '0'; -- Define o estado inicial ('0') no reset
-    elsif (rising_edge(CLK)) then 
-        PS <= NS;
-    end if;
-end process sync_proc;
 
-    -- Externalizar estados
-    SS <= PS;
-
-    -- Processo combinacional
-    comb_proc: process(PS, In_Car) begin
-      case PS is
-          when '0' =>
-              if (In_Car='1') then Out_Car<='1'; NS <= '1';
-              else Out_Car<='0'; NS <= PS;
-              end if;
-          when '1' =>
-              if (In_Car='1') then Out_Car<='0'; NS <= PS;
-              else Out_Car<='0'; NS <= '0';
-              end if;
-          when others =>  
-            NS <= '0';     
-            Out_Car <= 'X'; 
-          
-      end case;
-    end process comb_proc;
-end car_detector;
-
---OBS.:RST tem é uma das variáveis que devem ser inicializadas no projeto completo
+    process(CLK, Set)
+    begin
+        -- Set assíncrono (segunda prioridade)
+        if (Set'event and Set = '1') then
+            Q <= '1';
+        -- Lógica síncrona dependente do clock
+        elsif (CLK'event and CLK = '1') then  -- Reset      
+                Q <= '0';
+        end if;
+    end process;
+end architecture;

--- a/src/components/map_range.vhd
+++ b/src/components/map_range.vhd
@@ -1,17 +1,22 @@
--- Mapeador de Range
--- 
--- Recebe uma entranda signed de N bits
--- Transforma em uma saida signed de M bits
--- A saida se relaciona proporcionalmente com a entrada
--- Idealmente, M tem 5 bits podendo influenciar em no máximo 16s o tempo do sinal
--- Vamos adotar o uso de  "generic"  para poder alterar esse valor conforme necessário
-
--- Da forma em que está escrito o código precisa de uma saida M de no mínimo 4 bits
--- 
 -- Integrantes:
 -- * Guilherme Augusto
 -- * Pedro Armando
 -- * Pedro Pessoa
+--
+-- map_range
+-- Recebe uma entranda signed de N bits
+-- Transforma em uma saida signed de M bits
+-- C é a diferença abs de bits entre N e M
+-- Idealmente, M tem 5 bits podendo influenciar em no máximo 16s o tempo do sinal
+-- Vamos adotar o uso de  "generic"  para poder alterar esse valor conforme necessário
+-- Da forma em que está escrito o código precisa de uma saida M de no mínimo 4 bits
+  
+-- map_range
+-- Recebe uma entranda signed de N bits
+-- Transforma em uma saida signed de M bits
+-- Idealmente, M tem 5 bits podendo influenciar em no máximo 16s o tempo do sinal
+-- Vamos adotar o uso de  "generic"  para poder alterar esse valor conforme necessário
+-- Da forma em que está escrito o código precisa de uma saida M de no mínimo 4 bits
   
 library ieee;
 use ieee.std_logic_1164.all;
@@ -20,7 +25,7 @@ use ieee.numeric_std.all;
 
 entity map_range is
   generic (
-      N : integer := 10;
+      N : integer := 7;
       M : integer := 5
     );
 
@@ -33,38 +38,19 @@ end entity;
 
 
 ARCHITECTURE Behavioral OF map_range IS
+signal en0: signed(M-1 downto 0); --vetor do enable 
+signal saida: std_logic_vector(M-1 downto 0);--signal para saida
+
+
 BEGIN
-    PROCESS(a, e0) 
-        VARIABLE Max_SN_val : INTEGER;
-        VARIABLE Max_SM_val : INTEGER;
-        VARIABLE A_val      : INTEGER;
-        VARIABLE S_val      : INTEGER;
-    BEGIN
-        
-        IF e0 = '1' THEN -- calcula o resultado da saida
-            
-            -- Lógica de Escalonamento 
-            A_val := TO_INTEGER(ABS(a)); 
-            Max_SN_val := 2**(N-1) - 1; 
-            Max_SM_val := 2**(M-1) - 1;
-            
-            IF Max_SN_val /= 0 THEN
-                S_val := (A_val * Max_SM_val) / Max_SN_val;
-            ELSE
-                S_val := 0; 
-            END IF;
 
-            -- Atribuição de Sinal 
-            IF a(N-1) = '1' THEN
-                S <= TO_SIGNED(-S_val, M);
-            ELSE
-                S <= TO_SIGNED(S_val, M);
-            END IF;
-
-        ELSE --zera a saida
-          S <= (OTHERS => '0'); 
-            
-        END IF;
+  -- Caso os valores de M e N sejam alterados, substituir 2 pela diferença entre M e N
+  saida <= std_logic_vector(a(N-1 downto 2));
+  
+  en0 <= (others => e0);     	--Enable em um código dataflow
+  
+  s <= 	signed(saida) when e0 = '1' else
+  		signed(en0)	when e0 = '0';	
         
-    END PROCESS;
+    
 END ARCHITECTURE Behavioral;

--- a/tests/tb_car_detector.vhd
+++ b/tests/tb_car_detector.vhd
@@ -17,39 +17,33 @@ architecture testbench of tb_car_detector is
 
     component car_detector is
         port (
-            In_Car  : in  std_logic;
-            CLK     : in  std_logic;
-            RST     : in  std_logic;
-            Out_Car : out std_logic;
-            SS      : out std_logic
+            SET	: in  std_logic;
+            CLK : in  std_logic;
+            Q 	: out std_logic
         );
     end component;
 
-
-    signal in_car_tb  : std_logic := '0';
-    signal clk_tb     : std_logic := '0';
-    signal rst_tb     : std_logic := '1';
-    signal out_car_tb : std_logic := '0';
-    signal ss_tb      : std_logic := '0';
+   
+    signal Q_tb  	: std_logic := '0';
+    signal SET_tb 	: std_logic := '0';
+    signal CLK_tb 	: std_logic := '0';
 
 begin
 
     uut: car_detector
-        port map (
-            In_Car  => in_car_tb,
-            CLK     => clk_tb,
-            RST     => rst_tb,
-            Out_Car => out_car_tb,
-            SS      => ss_tb
+        port map (          
+            Q 	=> Q_tb,
+            SET => SET_tb,
+            CLK => CLK_tb
         );
 
 
     clk_process: process
     begin
         while clk_enable loop
-            clk_tb <= '0';
+            CLK_tb <= '0';
             wait for CLK_PERIOD/2;
-            clk_tb <= '1';
+            CLK_tb <= '1';
             wait for CLK_PERIOD/2;
         end loop;
         wait;
@@ -57,24 +51,20 @@ begin
 
     test_process: process
     begin
-        rst_tb <= '1';
-        wait for 3 * CLK_PERIOD; 
-        rst_tb <= '0';
-        wait for 2 * CLK_PERIOD; 
         
-        in_car_tb <= '1';
+        SET_tb <= '1';
         wait for 1 * CLK_PERIOD; 
         
-        in_car_tb <= '1';
+        SET_tb <= '0';
         wait for 2 * CLK_PERIOD;
         
-        in_car_tb <= '0';
+        SET_tb <= '1';
+        wait for CLK_PERIOD/4;
+        
+        SET_tb <= '0'; 
         wait for 1 * CLK_PERIOD;
         
-        in_car_tb <= '1'; 
-        wait for 1 * CLK_PERIOD;
-        
-        in_car_tb <= '0';
+        SET_tb <= '1';
         wait for 4 * CLK_PERIOD; 
         
         clk_enable <= false; 

--- a/tests/tb_map_range.vhd
+++ b/tests/tb_map_range.vhd
@@ -12,14 +12,15 @@ END ENTITY tb_map_range;
 
 ARCHITECTURE behavioral OF tb_map_range IS
     
-    CONSTANT N_BITS_TB : INTEGER := 10;
+    CONSTANT N_BITS_TB : INTEGER := 7;
     CONSTANT M_BITS_TB : INTEGER := 5;
+    
 
     SIGNAL tb_done : BOOLEAN := FALSE;
 
     COMPONENT map_range
         GENERIC (
-            N : INTEGER := 10;
+            N : INTEGER := 7;
             M : INTEGER := 5
         );
         PORT (
@@ -50,42 +51,42 @@ BEGIN
     BEGIN
         -- Estímulos para o teste
         e0_tb <= '0';
-        a_tb <= "0011111010";  -- 250 de 511
+        a_tb <= "1000001";  -- -63
         wait for 10 ns;
         
-        a_tb <= "0001111000";  -- 120 de 511
+        a_tb <= "0001111";  -- 15
         wait for 10 ns;
         
-        a_tb <= "0111111111";  -- 511 de 511
+        a_tb <= "0111111";  -- 63
         wait for 10 ns;
         
-        a_tb <= "1000000001";  -- 511 negativo de 511
+        a_tb <= "0011110";  -- 30
         wait for 10 ns;
         
-        a_tb <= "1100000110";  -- 250 negativo de 511
+        a_tb <= "1100010";  -- -30
         wait for 10 ns;
         
-        a_tb <= "1110001000";  -- 120 negativo de 511
+        a_tb <= "1110001";  -- -15
         wait for 10 ns;
         
         -- Alteração do sinal e0_tb
         e0_tb <= '1';
-        a_tb <= "0011111010";  -- 250 de 511
+        a_tb <= "1000001";  -- -63
         wait for 10 ns;
         
-        a_tb <= "0001111000";  -- 120 de 511
+        a_tb <= "0001111";  -- 15
         wait for 10 ns;
         
-        a_tb <= "0111111111";  -- 511 de 511
+        a_tb <= "0111111";  -- 63
         wait for 10 ns;
         
-        a_tb <= "1000000001";  -- 511 negativo de 511
+        a_tb <= "0011110";  -- 30
         wait for 10 ns;
         
-        a_tb <= "1100000110";  -- 250 negativo de 511
+        a_tb <= "1100010";  -- -30
         wait for 10 ns;
         
-        a_tb <= "1110001000";  -- 120 negativo de 511
+        a_tb <= "1110001";  -- -15
         wait for 10 ns;
         
         wait;


### PR DESCRIPTION
Redução da abstração comportamental dos componentes map_range e car_detector. Espera-se que os componentes se comportem da mesma similar a anterior. 

Como a diferença de bits entre a entrada e a saída de map_range é comparativamente pequena, a lógica para definir a saída foi alterada. Ao invés de usar um proporção direta, os bits mais significativos são considerados.

Caso exista uma diferença significativa entre as constantes M e N, favor utilizar a versão anterior de map_range.

A versão anterior de car_detector não deve ser adotada sob nenhuma hipótese.


----------------ENGLISH---------------------------------------------------

Reduction of the behavioral abstraction of the map_range and car_detector components. The components are expected to behave similarly to the previous version.

Since the bit difference between the input and output of map_range is comparatively small, the logic for defining the output has been changed. Instead of using a direct ratio, the most significant bits are considered.

If there is a significant difference between the constants M and N, please use the previous version of map_range.

The previous version of car_detector should not be adopted under any circumstances.