### PR TITLE
Add declaracao dos componentes estruturais

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,7 @@ lint:
 	ghdl syntax src/**/*.vhd **/*.vhd
 
 
+.PHONY: lint
+clean:
+	rm -f tb_* *.vcd *.cf *.o
+

--- a/src/bloco_controle.vhd
+++ b/src/bloco_controle.vhd
@@ -1,0 +1,46 @@
+-- Bloco de controle do semctl (RTL)
+--
+-- 
+-- == I/O Externo
+-- 
+-- input:
+--   clk: 1 bit
+--   rst: 1 bit
+--   in_mad: 1 bit    - Ativa modo madrugada
+-- output:
+--   out_fsm: 10 bits - Saida da FSM (one-hot encoding)
+--   sem1: 2 bits     - Saida para semaforo de carro 1
+--   sem2: 2 bits     - Saida para semaforo de carro 2
+--   ped1: 2 bits     - Saida para semaforo de pedestre 1
+--   ped2: 2 bits     - Saida para semaforo de pedestre 2
+--   ped3: 2 bits     - Saida para semaforo de pedestre 3
+-- 
+-- 
+-- == I/O Interno
+-- 
+-- input:
+--   count_done: 1 bit    - Sinaliza que o contador terminou a contagem
+--   
+-- output:
+--   car1_enable: 1 bits  - Enable para sensor de carro 1
+--   car2_enable: 1 bits  - Enable para sensor de carro 2
+--   polaridade: 1 bits   - Representa a polaridade do ciclo. 1 = ciclo em que sem2 abre
+--
+-- 
+-- Integrantes:
+-- * Guilherme Augusto
+-- * Pedro Armando
+-- * Pedro Pessoa
+
+library IEEE;
+  use IEEE.STD_LOGIC_1164.ALL;
+  use IEEE.NUMERIC_STD.ALL;
+
+
+entity bloco_controle is
+end entity;
+
+
+architecture structural of bloco_controle is
+begin
+end architecture;

--- a/src/bloco_operacional.vhd
+++ b/src/bloco_operacional.vhd
@@ -1,0 +1,38 @@
+-- Bloco de operacional / Caminho de Dados (RTL)
+-- 
+-- 
+-- == I/O Externo
+-- 
+-- input:
+--   in_car1: 1 bits  - Enable para sensor de carro 1
+--   in_car2: 1 bits  - Enable para sensor de carro 2
+-- output: (nenhum)
+-- 
+-- 
+-- == I/O Interno
+-- 
+-- input:
+--   car1_enable: 1 bits  - Enable para sensor de carro 1
+--   car2_enable: 1 bits  - Enable para sensor de carro 2
+--   polaridade: 1 bits   - Representa a polaridade do ciclo. 1 = ciclo em que sem2 abre
+-- output:
+--   count_done: 1 bit    - Sinaliza que o contador terminou a contagem
+-- 
+--
+-- Integrantes:
+-- * Guilherme Augusto
+-- * Pedro Armando
+-- * Pedro Pessoa
+
+library IEEE;
+  use IEEE.STD_LOGIC_1164.ALL;
+  use IEEE.NUMERIC_STD.ALL;
+
+
+entity bloco_operacional is
+end entity;
+
+
+architecture structural of bloco_operacional is
+begin
+end architecture;

--- a/src/components/dynamic_countdown.vhd
+++ b/src/components/dynamic_countdown.vhd
@@ -1,0 +1,33 @@
+-- Contador regresssivo dinamico
+--
+-- Tempo do contador pode ser configurado para aumentar ou diminuar
+-- uma quantidade especificada pelo valor de entrada dinamico.
+--
+-- A nova configuração entra em vigor no proximo ciclo de contagem.
+--
+-- 
+-- input:
+--   increment: 1 bit   - Valor a ser acrecido ao volor da contagem
+--   default: 1 bit     - Valor padrao para o semaforo
+--   rst: 1 bit         - Reseta o contador para o valor inicial
+--   clk: 1 bit
+-- output:
+--   count_done: 1 bit  - Sinaliza que o contador chegou ao fim
+--
+-- Integrantes:
+-- * Guilherme Augusto
+-- * Pedro Armando
+-- * Pedro Pessoa
+
+library IEEE;
+  use IEEE.STD_LOGIC_1164.ALL;
+  use IEEE.NUMERIC_STD.ALL;
+
+
+entity dynamic_countdown is
+end entity;
+
+
+architecture structural of dynamic_countdown is
+begin
+end architecture;

--- a/src/components/sensor_processor.vhd
+++ b/src/components/sensor_processor.vhd
@@ -1,0 +1,35 @@
+-- Processador de sinais
+--
+-- Recebe sinal dos sensores de carro e calcula a diferença dentros
+-- das especificações do projeto.
+--
+-- 
+-- input:
+--   car1_in: 1 bit       - Entrada do sensor carro 1
+--   car1_enable: 1 bit   - Enable para carro 1
+--   car2_in: 1 bit       - Entrada do sensor carro 2
+--   car2_enable: 1 bit   - Enable para carro 2
+--   rst: 1 bit           - Zera memoria interna (contagem de carros)
+--   enable: 1 bit        - Ativa ou congela contador
+--   polariadde: 1 bit    - Polaridade da saida
+--   clk: 1 bit
+-- output:
+--   data_out: (-15 a 16) - Valor a ser incrementado no contador
+-- 
+-- Integrantes:
+-- * Guilherme Augusto
+-- * Pedro Armando
+-- * Pedro Pessoa
+
+library IEEE;
+  use IEEE.STD_LOGIC_1164.ALL;
+  use IEEE.NUMERIC_STD.ALL;
+
+
+entity sensor_processor is
+end entity;
+
+
+architecture structural of sensor_processor is
+begin
+end architecture;


### PR DESCRIPTION
Esse PR adiciona a declaração (sem implementação) e documentação dos componentes estruturais de mais alto nivel.

Além do bloco de controle e bloco operacional tipicos do projeto RTL, propus criar um componente de nivel medio para encapsular o processamento dos sensores de carro e outro para encapsular o contador que recebe um incremento (veja diagrama abaixo "Processador de Sensores" e "Contador Regressivo Dinamico"). O propósito é evitar que o `bloco_operacional` fique muito complexo e dificil de entender.

A implementação destes componentes deverá ser estrutural, utilizando componentes em `src/componentes`. O componente `bloco_controle` deve extrair o código do componente `src/semctl.vhd`.

Ele foi feito seguindo os diagramas:

<img width="1212" height="663" alt="image" src="https://github.com/user-attachments/assets/e24cca7d-4f57-4afc-8b78-a21500d7a972" />
<img width="1358" height="592" alt="image" src="https://github.com/user-attachments/assets/de038e61-6436-4eb8-9fea-bcab05760f1f" />
